### PR TITLE
Bumping js-beautify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "gulp-util": "~3.0.0",
     "through2": "~0.5.0",
-    "js-beautify": "~1.4.2",
+    "js-beautify": "~1.5.4",
     "deepmerge": "~0.2.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrading js-beautify to v1.5.4 in order to use the 'end_with_newline' option.
